### PR TITLE
replace ruby String with Iowa::String to fix NoMethodError

### DIFF
--- a/src/iowa/Util.rb
+++ b/src/iowa/Util.rb
@@ -279,6 +279,7 @@ module Iowa
       pieces = thing.split(/::|#{File::SEPARATOR}/)
       parts = []
       pieces.each do |piece|
+        piece = Iowa::String.new(piece)
         x = [piece]
         x.push piece.snake_case if piece != piece.snake_case
         x.push piece.constant_case if piece != piece.constant_case


### PR DESCRIPTION
Trying to run my old IOWA app with ruby30 throws the following error:
```$ ruby30 isys.rb
/home/isys/.gem/ruby/3.0.0/gems/IOWA-1.0.3/src/iowa/Util.rb:283:in `block in find_class': undefined method `snake_case' for "RubyLogger":String (NoMethodError)
```
Looks like the `Iowa::String` called `pieces` got split into ruby `String` instances.